### PR TITLE
fix: remove emphasis prop from countdown

### DIFF
--- a/templates/components/countdown/countdown-1/template.yaml
+++ b/templates/components/countdown/countdown-1/template.yaml
@@ -3,7 +3,6 @@ options:
   expiresAt: =$fromMillis($toMillis($now()) + 1200000, '[Y]-[M]-[D01] [H01]:[m01]')
   align: left
   labels:
-    emphasis: medium
     isVisible: true
     position: top
   size: large

--- a/templates/components/countdown/countdown-2/template.yaml
+++ b/templates/components/countdown/countdown-2/template.yaml
@@ -3,7 +3,6 @@ options:
   expiresAt: =$fromMillis($toMillis($now()) + 432000000, '[Y]-[M]-[D01] [H01]:[m01]')
   align: right
   labels:
-    emphasis: high
     isVisible: true
     position: bottom
   size: small


### PR DESCRIPTION
The emphasis property has been removed from the countdown component. I fixed the templates.