### PR TITLE
chore: add category priority config

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -1823,8 +1823,6 @@
     "jig-list",
     "jig-calendar",
     "jig-composite",
-    "jig-document",
-    "jc-bar-chart",
-    "jc-countdown"
+    "jig-document"
   ]
 }

--- a/contents.json
+++ b/contents.json
@@ -40,7 +40,8 @@
       "name": "Default jig 6",
       "filePath": "templates/jigs/default/template-default-7.yaml",
       "previewImgSrc": "templates/jigs/default/template-default-7.png",
-      "templateRef": "jig-default"
+      "templateRef": "jig-default",
+      "groups": ["Scenarios"]
     },
     {
       "name": "Default jig 7",
@@ -183,16 +184,6 @@
           "name": "type-list",
           "filePath": "templates/jigs/composite/composite-1/element-2.yaml",
           "directory": "jigs"
-        }
-      ],
-      "jigFiles": [
-        {
-          "name": "type-default",
-          "path": "templates/jigs/composite/composite-1/element-1.yaml"
-        },
-        {
-          "name": "type-list",
-          "path": "templates/jigs/composite/composite-1/element-2.yaml"
         }
       ]
     },
@@ -1825,5 +1816,15 @@
         "datasource": "widgets/4x4/widget-4/datasource.yaml"
       }
     ]
-  }
+  },
+  "categoriesOrder": [
+    "Scenarios",
+    "jig-default",
+    "jig-list",
+    "jig-calendar",
+    "jig-composite",
+    "jig-document",
+    "jc-bar-chart",
+    "jc-countdown"
+  ]
 }


### PR DESCRIPTION
This PR adds a new field into contents.json for categories prioritization:
```json
"categoriesOrder": [
    "Scenarios",
    "jig-default",
    "jig-list",
    "jig-calendar",
    "jig-composite",
    "jig-document"
  ]
```