### PR TITLE
fix: removed the right element in 2x2 widhet 15

### DIFF
--- a/widgets/2x2/widget-15/template.yaml
+++ b/widgets/2x2/widget-15/template.yaml
@@ -10,9 +10,6 @@ options:
       leftElement:
         element: checkbox
         value: =(@ctx.current.item.status= 'Finished' ? true :false)
-      rightElement:
-        element: value
-        text: =@ctx.current.item.value
       style:
         isPositive: =(@ctx.current.item.status= 'Finished' ? true :false)
         isStrikeThrough: =(@ctx.current.item.status= 'Finished' ? true :false)


### PR DESCRIPTION
I removed the right element from the template for 2x2 widget 15. This right element is not displayed even on the preview and does not refer to any value from datasources.

Related to https://app.clickup.com/t/8687btbqq