### PR TITLE
fix: new url for image in 4x2 widget 15

### DIFF
--- a/widgets/4x2/widget-15/template.yaml
+++ b/widgets/4x2/widget-15/template.yaml
@@ -10,4 +10,4 @@ options:
       iconColor: color4
   isContentOverlaid: false
   source:
-    uri: http://freemondo.com/style/desktop/images/picpage/test3.png
+    uri: https://images.unsplash.com/photo-1585848705732-e938bf971da6?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTJ8fE9ybGljayVDMyVBOSUyMGhvcnl8ZW58MHx8MHx8fDA%3D


### PR DESCRIPTION
I changed the url for the image in the template for the 4x2 widget 15

Related to https://app.clickup.com/t/8687btfz1