### PR TITLE
fix: min value for line and bar charts

### DIFF
--- a/templates/components/line-chart/line-chart-8/template.yaml
+++ b/templates/components/line-chart/line-chart-8/template.yaml
@@ -22,6 +22,8 @@ options:
         currency: USD
         compactDisplay: short
         notation: compact
+    min: 20000
+    max: 60000
   xAxis:
     tickAmount: 3
     categories:

--- a/templates/jigs/default/default-1/template.yaml
+++ b/templates/jigs/default/default-1/template.yaml
@@ -10,7 +10,7 @@ children:
       yAxis:
         isHidden: false
         max: 1200
-        min: 0
+        min: 500
         labels:
           format:
             numberStyle: currency

--- a/widgets/2x2/widget-12/template.yaml
+++ b/widgets/2x2/widget-12/template.yaml
@@ -27,7 +27,7 @@ options:
             notation: compact
             numberStyle: currency
         max: 1200
-        min: 0
+        min: 600
         tickAmount: 3
   top:
     type: component.trend

--- a/widgets/4x2/widget-4/template.yaml
+++ b/widgets/4x2/widget-4/template.yaml
@@ -29,6 +29,7 @@ options:
                   notation: standard
                   numberStyle: currency
               tickAmount: 3
+              min: 51000
         top:
           type: component.titles
           options:
@@ -62,6 +63,7 @@ options:
                   notation: compact
                   numberStyle: currency
               tickAmount: 3
+              min: 27000
         top:
           type: component.titles
           options:

--- a/widgets/4x4/widget-3/template.yaml
+++ b/widgets/4x4/widget-3/template.yaml
@@ -33,7 +33,7 @@ options:
           format:
             notation: compact
             numberStyle: currency
-        min: 0
+        min: 37000
         tickAmount: 7
   top:
     type: component.titles


### PR DESCRIPTION
Fixed minimum values ​​for bar and line charts as Redux doesn't support adjusting the chart based on values ​​from data sources.

Related to https://app.clickup.com/t/8687g1xnv