### PR TITLE
chore: Updated documentation URLs to GitBook URLs.

### DIFF
--- a/templates/components/list/list-1/template.yaml
+++ b/templates/components/list/list-1/template.yaml
@@ -34,7 +34,7 @@ options:
             onPress:
               type: action.open-url
               options:
-                url: https://docs.jigx.com/examples/go-to
+                url: https://docs.jigx.com/examples/readme/actions/go-to
         right:
           - label: label
             icon: pencil-2
@@ -42,4 +42,4 @@ options:
             onPress:
               type: action.open-url
               options:
-                url: https://docs.jigx.com/examples/go-to
+                url: https://docs.jigx.com/examples/readme/actions/go-to

--- a/templates/components/list/list-10/template.yaml
+++ b/templates/components/list/list-10/template.yaml
@@ -17,4 +17,4 @@ options:
         onPress:
           type: action.open-url
           options:
-            url: https://docs.jigx.com/examples/set-state
+            url: https://docs.jigx.com/examples/readme/actions/set-state

--- a/templates/jigs/calendar/calendar-1/template.yaml
+++ b/templates/jigs/calendar/calendar-1/template.yaml
@@ -6,11 +6,11 @@ item:
   type: component.event
   options:
     title: =@ctx.current.item.title
-    from: 
+    from:
       text: =@ctx.current.item.eventStart
       format:
         dateFormat: lll
-    to: 
+    to:
       text: =@ctx.current.item.eventEnd
       format:
         dateFormat: lll
@@ -23,4 +23,4 @@ actions:
       - type: action.open-url
         options:
           title: Add appointment
-          url: https://docs.jigx.com/examples/submit-form
+          url: https://docs.jigx.com/examples/readme/actions/submit-form

--- a/templates/jigs/default/default-1/template.yaml
+++ b/templates/jigs/default/default-1/template.yaml
@@ -72,4 +72,4 @@ actions:
       - type: action.open-url
         options:
           title: New Expense
-          url: https://docs.jigx.com/examples/submit-form
+          url: https://docs.jigx.com/examples/readme/actions/submit-form

--- a/templates/jigs/default/default-2/template.yaml
+++ b/templates/jigs/default/default-2/template.yaml
@@ -70,11 +70,11 @@ children:
           onPress:
             type: action.open-url
             options:
-              url: https://docs.jigx.com/examples/pUyK-web-view
+              url: https://docs.jigx.com/examples/readme/components/web-view
 
 actions:
   - children:
       - type: action.open-url
         options:
           title: Edit employee
-          url: https://docs.jigx.com/examples/execute-entity
+          url: https://docs.jigx.com/examples/readme/actions/execute-entity

--- a/templates/jigs/default/default-3/template.yaml
+++ b/templates/jigs/default/default-3/template.yaml
@@ -76,4 +76,4 @@ actions:
       - type: action.open-url
         options:
           title: Add employee
-          url: https://docs.jigx.com/examples/submit-form
+          url: https://docs.jigx.com/examples/readme/actions/submit-form

--- a/templates/jigs/list/list-1/template.yaml
+++ b/templates/jigs/list/list-1/template.yaml
@@ -64,7 +64,7 @@ actions:
       - type: action.open-url
         options:
           title: Buy products with low inventory
-          url: https://docs.jigx.com/examples/action-list
+          url: https://docs.jigx.com/examples/readme/actions/action-list
 
 summary:
   children:

--- a/templates/jigs/list/list-12/template.yaml
+++ b/templates/jigs/list/list-12/template.yaml
@@ -30,4 +30,4 @@ item:
       onPress:
         type: action.open-url
         options:
-          url: https://docs.jigx.com/examples/set-state
+          url: https://docs.jigx.com/examples/readme/actions/set-state

--- a/templates/jigs/list/list-17/template.yaml
+++ b/templates/jigs/list/list-17/template.yaml
@@ -27,14 +27,14 @@ item:
         - onPress:
             type: action.open-url
             options:
-              url: https://docs.jigx.com/examples/go-to
+              url: https://docs.jigx.com/examples/readme/actions/go-to
           label: Primary Action
           color: primary
           icon: alarm-bell
         - onPress:
             type: action.open-url
             options:
-              url: https://docs.jigx.com/examples/go-to
+              url: https://docs.jigx.com/examples/readme/actions/go-to
           label: Secondary Action
           color: warning
           icon: alert-triangle

--- a/templates/jigs/list/list-2/template.yaml
+++ b/templates/jigs/list/list-2/template.yaml
@@ -24,7 +24,6 @@ filter:
     - title: Lost
       value: Unsuccessful
 
-
 data: =$filter($filter(@ctx.datasources.components, function($v){$contains($string($v.name),$string(@ctx.jig.state.searchText != null ? @ctx.jig.state.searchText:'')) }), function($v, $a, $i) { @ctx.jig.state.filter = 'ALL' or $v.result = @ctx.jig.state.filter })[]
 item:
   type: component.list-item
@@ -43,7 +42,7 @@ item:
       isStrikeThrough: =(@ctx.current.item.status= 'Finished' ? true :false)
     rightElement:
       element: value
-      text: 
+      text:
         text: =@ctx.current.item.value
         format:
           numberStyle: currency
@@ -54,7 +53,7 @@ actions:
       - type: action.open-url
         options:
           title: Add new opportunity
-          url: https://docs.jigx.com/examples/submit-form
+          url: https://docs.jigx.com/examples/readme/actions/submit-form
 
 summary:
   children:

--- a/templates/jigs/list/list-3/template.yaml
+++ b/templates/jigs/list/list-3/template.yaml
@@ -36,4 +36,4 @@ actions:
       - type: action.open-url
         options:
           title: Add task
-          url: https://docs.jigx.com/examples/submit-form
+          url: https://docs.jigx.com/examples/readme/actions/submit-form

--- a/templates/jigs/list/list-4/template.yaml
+++ b/templates/jigs/list/list-4/template.yaml
@@ -34,4 +34,4 @@ actions:
       - type: action.open-url
         options:
           title: Add
-          url: https://docs.jigx.com/examples/submit-form
+          url: https://docs.jigx.com/examples/readme/actions/submit-form

--- a/templates/jigs/list/list-6/template.yaml
+++ b/templates/jigs/list/list-6/template.yaml
@@ -38,4 +38,4 @@ actions:
       - type: action.open-url
         options:
           title: Add
-          url: https://docs.jigx.com/examples/submit-form
+          url: https://docs.jigx.com/examples/readme/actions/submit-form

--- a/templates/jigs/list/list-7/template.yaml
+++ b/templates/jigs/list/list-7/template.yaml
@@ -45,5 +45,4 @@ actions:
       - type: action.open-url
         options:
           title: Add
-          url: https://docs.jigx.com/examples/submit-form
-
+          url: https://docs.jigx.com/examples/readme/actions/submit-form


### PR DESCRIPTION
Documentation URLs were used in the templates for example action.open-url. Made the update to use the new documentation path for GitBook